### PR TITLE
ci: 利用GitHub Action编译生成可执行文件并上传到release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,55 @@
+name: Build&Release
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'tag_name'
+        default: 2.3
+
+      name:
+        description: 'release name'
+        default: 2.3
+        
+      body:
+        description: 'release body'
+        default: 
+        
+      draft:
+        description: 'Is release draft?'
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    name: Build release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.ref }}
+          
+      - name: Setup Go
+        uses: actions/setup-go@v5.0.0
+        with:
+          go-version: 1.22.2
+
+      - name: Build
+        run:  |
+          cd gossh
+          make -j all
+        
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          name: ${{ inputs.name }}
+          body: ${{ inputs.body }}
+          draft: ${{ inputs.draft }}
+          files: |
+            gossh/WebSSH-linux-amd64
+            gossh/WebSSH-linux-arm64
+            gossh/WebSSH-macos-amd64
+            gossh/WebSSH-windows-amd64.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gossh/Makefile
+++ b/gossh/Makefile
@@ -1,0 +1,22 @@
+
+.PHONY: clean all
+
+all: linux-amd64 linux-arm64 macos-amd64 windows-amd64
+
+linux-amd64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o WebSSH-linux-amd64
+
+linux-arm64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o WebSSH-linux-arm64
+
+macos-amd64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o WebSSH-macos-amd64
+
+windows-amd64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o WebSSH-windows-amd64.exe
+
+WebSSH:
+	go build -o WebSSH
+
+clean:
+	rm -f WebSSH-linux-amd64 WebSSH-linux-arm64 WebSSH-macos-amd64 WebSSH-windows-amd64.exe


### PR DESCRIPTION
+ 目前是人工点击`Run workflow`按钮触发，可按需修改
+ release的结果参考<https://github.com/nICEnnnnnnnLee/WebSSH/releases/tag/2.3>